### PR TITLE
Small fix for Power Menu if system has no System.CanPowerDown, System…

### DIFF
--- a/1080i/DialogButtonMenu.xml
+++ b/1080i/DialogButtonMenu.xml
@@ -167,6 +167,7 @@
                     <texture>special://skin/extras/BigIcons/AlarmClock.png</texture>
                     <animation effect="fade" start="100" end="55" time="0" condition="!Control.HasFocus(3) + !Control.HasFocus(15)">Conditional</animation>
                     <include>Objects_ShutdownMenuIcon</include>
+                    <visible>System.CanPowerDown</visible>
                 </control>
                 <control type="image">
                     <texture>special://skin/extras/BigIcons/Battery.png</texture>


### PR DESCRIPTION
Small fix for Power Menu if system has no System.CanPowerDown, SystemCanHibernate, System.CanSuspend, System.CanReboot features on various Linux distros.
before: http://i.imgur.com/ZJbi3lX.jpg
after: http://i.imgur.com/2gd5aYR.jpg

P.S.: On Windows all ok :))
