### PR TITLE
fix reload option in context menu & fix name of  " choose art "

### DIFF
--- a/1080i/DialogContextMenu.xml
+++ b/1080i/DialogContextMenu.xml
@@ -14,13 +14,13 @@
              	<posx>0</posx>
 	            <posy>0</posy>
 				<width>462</width>
-			    <height>1100</height>
+			    <height>1040</height>
 			    <texture fallback="dialogs/context_middle_alt.png">$VAR[ContextMiddleVar]</texture>
                 <colordiffuse>$VAR[SpotColorVar2]</colordiffuse>
         </control>
 	    <control type="grouplist" id="996">
             <width>462</width>
-		    <height max="1080">auto</height>
+		    <height max="1000">auto</height>
 			<posx>-1</posx>
 	        <posy>0</posy>
             <control type="button" id="2001">
@@ -206,7 +206,7 @@
                 <textcolor>context</textcolor>
                 <focusedcolor>white2</focusedcolor>
                 <colordiffuse>$VAR[SpotColorVar2]</colordiffuse>
-                <include>ReloadWindowOnClick</include>
+                <onclick>ReloadSkin()</onclick>
 			</control>			
         </control>
         <control type="image" id="997">

--- a/1080i/custom_1119_ExtrasDialog.xml
+++ b/1080i/custom_1119_ExtrasDialog.xml
@@ -89,11 +89,11 @@
 				<visible>System.HasAddon(script.artwork.downloader) + [Container.Content(movies) | Container.Content(tvshows)]</visible>
 			</control>
 			<control type="button" id="116">
-				<description>Artwork downloader button choose art</description>
+				<description>Kodi choose art</description>
 				<include>Objects_CommonSettingsButton</include>
 				<onclick>Dialog.Close(1119)</onclick>
 				<onclick>SendClick(2003,10)</onclick>
-				<label>$INFO[System.AddonTitle(script.artwork.downloader),,: $LOCALIZE[13511]]</label>
+				<label>$LOCALIZE[13511]</label>
 				<visible>System.HasAddon(script.artwork.downloader) + [Container.Content(movies) | Container.Content(tvshows) | Container.Content(episodes) | Container.Content(seasons)]</visible>
 			</control>
 			<control type="button" id="117">


### PR DESCRIPTION
change reload option now to internal "ReloadSkin()" command - should work now with cache image problems and reload whole skin
fix also the dimensions of the dialogcontextmenu icon ( its not complete from top to bottom now - there is now some space between top and bottom are )
fix name in extras from "artwork downloader:choose art" to just " choose art ", because this command is an INTERNAL Kodi command, and have nothing to do with artwork downloader ;)
