### PR TITLE
Movieset Case open animation fix

### DIFF
--- a/1080i/Viewtype_ShowcaseMovies.xml
+++ b/1080i/Viewtype_ShowcaseMovies.xml
@@ -872,7 +872,7 @@
 		<width>324</width>
 		<height>437</height>
 		<fadetime>0</fadetime>
-		<visible>Skin.HasSetting(usecases) + [container.content(sets) | container.content(movies) | Container.Content(musicvideos)]</visible>
+		<!-- <visible>Skin.HasSetting(usecases) + [container.content(sets) | container.content(movies) | Container.Content(musicvideos)]</visible> -->
 	</include>
 	<!-- Movie Showcase Variables: Main thumbs -->
 	<include name="MovieShowcaseThumbDimensions">


### PR DESCRIPTION
Animation of Movieset case when no Case is selected is fixed - poster wasnt shown before - result was a strange looking animation - should be fixed now
