### PR TITLE
small List View and Kodiflix fixes

### DIFF
--- a/1080i/View_800_KodiFlix.xml
+++ b/1080i/View_800_KodiFlix.xml
@@ -1498,7 +1498,7 @@
 					<width>198</width>
 					<height>299</height>
 					<aspectratio align="center" aligny="center">stretch</aspectratio>
-					<texture background="true" fallback="thumbs/fallback_episode_tp.png">$VAR[ListPosterVar]</texture>
+					<texture background="true" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterVar]</texture>
 					<bordertexture border="15">thumbs/thumb_border.png</bordertexture>
 					<include>KodiFlixDimAnimation</include>
 					<bordersize>6</bordersize>
@@ -1509,7 +1509,7 @@
 					<width>198</width>
 					<height>299</height>
 					<aspectratio align="center" aligny="center">stretch</aspectratio>
-					<texture background="true" flipy="true" diffuse="thumbs/reflection_diffuse_sq.png" fallback="thumbs/fallback_episode_tp.png">$VAR[ListPosterVar]</texture>
+					<texture background="true" flipy="true" diffuse="thumbs/reflection_diffuse_sq.png" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterVar]</texture>
 					<bordertexture border="15">thumbs/thumb_border_fade.png</bordertexture>
 					<bordersize>6</bordersize>
 					<include>KodiFlixDimAnimation</include>
@@ -1645,7 +1645,7 @@
 				</control>
 				<control type="image">
 					<include>KodiFlixMovieThumb</include>
-					<texture background="true" diffuse="thumbs/thumb_mask.png" fallback="DefaultVideoBigPoster.png">$VAR[ListPosterVar]</texture>
+					<texture background="true" diffuse="thumbs/thumb_mask.png" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterVar]</texture>
 					<include>KodiFlixOpenCase</include>
 					<visible>Skin.HasSetting(usecases) + [Container.Content(movies) | Container.Content(sets)] + Skin.Hassetting(KodiFlixCases) + !stringcompare(ListItem.Label,..) + Skin.HasSetting(KodiFlixOpenCase) + !IsEmpty(ListItem.Art(discart))</visible>
 				</control>
@@ -2511,7 +2511,7 @@
 					<width>198</width>
 					<height>299</height>
 					<aspectratio align="center" aligny="center">stretch</aspectratio>
-					<texture background="true" fallback="thumbs/fallback_episode_tp.png">$VAR[ListPosterVar]</texture>
+					<texture background="true" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterVar]</texture>
 					<bordertexture border="15">thumbs/thumb_border.png</bordertexture>
 					<bordersize>6</bordersize>
 					<include>KodiFlixDimAnimation</include>
@@ -2522,7 +2522,7 @@
 					<width>198</width>
 					<height>299</height>
 					<aspectratio align="center" aligny="center">stretch</aspectratio>
-					<texture background="true" flipy="true" diffuse="thumbs/reflection_diffuse_sq.png" fallback="thumbs/fallback_episode_tp.png">$VAR[ListPosterVar]</texture>
+					<texture background="true" flipy="true" diffuse="thumbs/reflection_diffuse_sq.png" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterVar]</texture>
 					<bordertexture border="15">thumbs/thumb_border_fade.png</bordertexture>
 					<bordersize>6</bordersize>
 					<animation type="Conditional" reversible="false" condition="Skin.HasSetting(KodiFlixDimItems)">
@@ -2591,6 +2591,7 @@
 				</control>
 			</focusedlayout>
 		</control>
+		
 		<control type="image">
 			<left>45</left>
 			<top>620</top>

--- a/1080i/Viewtype_List.xml
+++ b/1080i/Viewtype_List.xml
@@ -282,7 +282,7 @@
 						<top>-40</top>
 						<width>550</width>
 						<height>825</height>
-						<texture background="true" diffuse="thumbs/movieposter_mask.png">$VAR[ListPosterVar]</texture>
+						<texture background="true" diffuse="thumbs/movieposter_mask.png" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterVar]</texture>
 						<fadetime>IconCrossfadeTime2</fadetime>
 						<bordertexture border="19.5">thumbs/poster_shadow.png</bordertexture>
 						<bordersize>19</bordersize>
@@ -294,7 +294,7 @@
 						<width>550</width>
 						<height>825</height>
 						<aspectratio scalediffuse="false">stretch</aspectratio>
-						<texture background="true" diffuse="thumbs/movieposter_mask.png" fallback="DefaultVideoBigPoster.png">$VAR[ListPosterBackupVar]</texture>
+						<texture background="true" diffuse="thumbs/movieposter_mask.png" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterBackupVar]</texture>
 						<fadetime>IconCrossfadeTime2</fadetime>
 						<bordertexture border="19.5">thumbs/poster_shadow.png</bordertexture>
 						<bordersize>19</bordersize>
@@ -309,7 +309,7 @@
 						<top>26</top>
 						<width>535</width>
 						<height>745</height>
-						<texture background="true" diffuse="thumbs/movieposter_mask.png">$VAR[ListPosterVar]</texture>
+						<texture background="true" diffuse="thumbs/movieposter_mask.png" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterVar]</texture>
 						<fadetime>IconCrossfadeTime2</fadetime>
 						<bordertexture border="19.5">thumbs/poster_shadow.png</bordertexture>
 						<bordersize>19</bordersize>
@@ -349,7 +349,7 @@
 						<top>770</top>
 						<width>510</width>
 						<height>765</height>
-						<texture diffuse="thumbs/movieposter_mask_reflect.png" flipy="true" background="true" fallback="DefaultVideoBigPoster.png">$VAR[ListPosterVar1]</texture>
+						<texture diffuse="thumbs/movieposter_mask_reflect.png" flipy="true" background="true" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterVar1]</texture>
 						<fadetime>IconCrossfadeTime2</fadetime>
 						<colordiffuse>d0FFFFFF</colordiffuse>
 						<visible>!Skin.HasSetting(genrethumbs)</visible>
@@ -358,7 +358,7 @@
 						<top>770</top>
 						<width>510</width>
 						<height>765</height>
-						<texture diffuse="thumbs/movieposter_mask_reflect.png" flipy="true" background="true" fallback="DefaultVideoBigPoster.png">$VAR[ListPosterVar]</texture>
+						<texture diffuse="thumbs/movieposter_mask_reflect.png" flipy="true" background="true" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterVar]</texture>
 						<fadetime>IconCrossfadeTime2</fadetime>
 						<colordiffuse>d0FFFFFF</colordiffuse>
 						<visible>Skin.HasSetting(genrethumbs)</visible>
@@ -368,7 +368,7 @@
 						<width>510</width>
 						<height>765</height>
 						<aspectratio scalediffuse="false">stretch</aspectratio>
-						<texture diffuse="thumbs/movieposter_mask_reflect.png" flipy="true" background="true" fallback="DefaultVideoBigPoster.png">$VAR[ListPosterBackupVar]</texture>
+						<texture diffuse="thumbs/movieposter_mask_reflect.png" flipy="true" background="true" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterBackupVar]</texture>
 						<fadetime>IconCrossfadeTime2</fadetime>
 						<colordiffuse>d0FFFFFF</colordiffuse>
 						<visible>IsEmpty(Control.GetLabel(3822))</visible>
@@ -1184,7 +1184,7 @@
 							<width>550</width>
 							<height>826</height>
 							<aspectratio aligny="bottom">stretch</aspectratio>
-							<texture background="true">$VAR[ListPosterVar]</texture>
+							<texture background="true" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterVar]</texture>
 							<fadetime>0</fadetime>
 							<colordiffuse>FF000000</colordiffuse>
 							<bordersize>17</bordersize>
@@ -1196,7 +1196,7 @@
 							<width>550</width>
 							<height>825</height>
 							<aspectratio aligny="bottom">stretch</aspectratio>
-							<texture background="true">$VAR[ListPosterVar]</texture>
+							<texture background="true" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterVar]</texture>
 							<bordertexture border="19,5">thumbs/thumbshadow.png</bordertexture>
 							<bordersize>19</bordersize>
 							<visible>[!Skin.HasSetting(listcdart) + Container.Content(movies)] | [Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes)]</visible>
@@ -1206,13 +1206,13 @@
 							<width>512</width>
 							<height>765</height>
 							<aspectratio aligny="bottom">stretch</aspectratio>
-							<texture diffuse="thumbs/diffuse_mirror3.png"  flipy="true" background="true" fallback="DefaultVideoBigPoster.png">$VAR[ListPosterVar]</texture>
+							<texture diffuse="thumbs/diffuse_mirror3.png"  flipy="true" background="true" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterVar]</texture>
 							<colordiffuse>d0FFFFFF</colordiffuse>
 							<fadetime>IconCrossfadeTime2</fadetime>
 							<visible>[!Skin.HasSetting(listcdart) + Container.Content(movies)] | [Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes)]</visible>
 						</control>
 						<control type="image">			<!-- Poster Mask backround with disc -->
-							<left>70</left>
+							<left>-19</left>
 							<top>-40</top>
 							<width>550</width>
 							<height>826</height>
@@ -1224,12 +1224,12 @@
 							<visible>Skin.HasSetting(listcdart) + Container.Content(movies)</visible>
 						</control>
 						<control type="image">     		<!-- Poster hard corner with disc -->
-							<left>70</left>
+							<left>-19</left>
 							<top>-40</top>
 							<width>550</width>
 							<height>825</height>
 							<aspectratio aligny="bottom">stretch</aspectratio>
-							<texture background="true">$VAR[ListPosterVar]</texture>
+							<texture background="true" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterVar]</texture>
 							<bordertexture border="19,5">thumbs/thumbshadow.png</bordertexture>
 							<bordersize>19</bordersize>
 							<visible>Skin.HasSetting(listcdart) + Container.Content(movies)</visible>
@@ -1240,7 +1240,7 @@
 							<width>512</width>
 							<height>765</height>
 							<aspectratio aligny="bottom">stretch</aspectratio>
-							<texture diffuse="thumbs/diffuse_mirror3.png"  flipy="true" background="true" fallback="DefaultVideoBigPoster.png">$VAR[ListPosterVar]</texture>
+							<texture diffuse="thumbs/diffuse_mirror3.png"  flipy="true" background="true" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterVar]</texture>
 							<colordiffuse>d0FFFFFF</colordiffuse>
 							<fadetime>IconCrossfadeTime2</fadetime>
 							<visible>Skin.HasSetting(listcdart) + Container.Content(movies)</visible>
@@ -1254,7 +1254,7 @@
 							<top>26</top>
 							<width>535</width>
 							<height>745</height>
-							<texture background="true" diffuse="thumbs/movieposter_mask.png">$VAR[ListPosterVar]</texture>
+							<texture background="true" diffuse="thumbs/movieposter_mask.png" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterVar]</texture>
 							<fadetime>IconCrossfadeTime2</fadetime>
 							<bordertexture border="19.5">thumbs/poster_shadow.png</bordertexture>
 							<bordersize>19</bordersize>
@@ -1317,7 +1317,7 @@
 							<top>787</top>
 							<width>497</width>
 							<height>680</height>
-							<texture flipy="true" background="true" diffuse="thumbs/movieposter_mask_reflect.png">$VAR[ListPosterVar]</texture>
+							<texture flipy="true" background="true" diffuse="thumbs/movieposter_mask_reflect.png" fallback="thumbs/fallback_poster_tp.png">$VAR[ListPosterVar]</texture>
 							<fadetime>IconCrossfadeTime2</fadetime>
 							<visible>Skin.HasSetting(genrethumbs)</visible>
 						</control>


### PR DESCRIPTION
List View: fix the position of cover when no round corners + nocase + cdart is enabled - before the cover was too much right
add/change the "no fanart" fallback to the views when no cover is available
Kodiflix View: change the episode no fanart fallbacks to poster fallbacks - episode fallback was stretched and poster fallback fits ;)
